### PR TITLE
Added 'newdata' argument to viterbi.msm (issue #18)

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -102,7 +102,6 @@ importFrom(mvtnorm, rmvnorm)
 importFrom(survival, Surv)
 importFrom(survival, survfit)
 importFrom(expm, expm)
-importFrom(pryr, modify_call)
 
 S3method(print, msm)
 S3method(summary, msm)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -102,6 +102,7 @@ importFrom(mvtnorm, rmvnorm)
 importFrom(survival, Surv)
 importFrom(survival, survfit)
 importFrom(expm, expm)
+importFrom(pryr, modify_call)
 
 S3method(print, msm)
 S3method(summary, msm)

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -1846,8 +1846,9 @@ viterbi.msm <- function(x, normboot=FALSE, newdata=NULL)
   
   if (!is.null(newdata)){
     ## initialise msm with new data but do not fit (hence fixedpars = TRUE)
-    x$call$data <- substitute(newdata)
-    newcall <- pryr::modify_call(x$call, list(fixedpars = TRUE))
+    newcall <- x$call
+    newcall$data <- substitute(newdata)
+    newcall$fixedpars <- TRUE
     xnew <- try(eval(newcall))
   } else {
     xnew <- x

--- a/man/viterbi.msm.Rd
+++ b/man/viterbi.msm.Rd
@@ -8,7 +8,7 @@
   observations, the Viterbi algorithm recursively constructs the path
   with the highest probability through the underlying states.  The
   probability of each hidden state is also computed for hidden Markov
-  models.
+  models, using the forward-backward algorithm.
 }
 
 \usage{
@@ -21,6 +21,10 @@ viterbi.msm(x, normboot=FALSE)
     maximum likelihood estimates of the model parameters are replaced by
     an alternative set of parameters drawn randomly from the asymptotic
     multivariate normal distribution of the MLEs.}
+  \item{newdata}{An optional data frame containing observations on which 
+  to construct the Viterbi path and forward-backward probabilities. It 
+  must be in the same format as the data frame used to fit \code{x}. 
+  If \code{NULL}, the data frame used to fit \code{x} is used.}
 }
 \value{
     A data frame with columns:


### PR DESCRIPTION
Resolves issue #18. The new argument is called 'newdata' to match base `predict` generic methods, but not precious about this so feel free to modify this or anything else to suit the package style. It uses `modify_call` from the `pryr` package.