### PR TITLE
Changed `seq` calls that use `length` to `length.out`.

### DIFF
--- a/R/hmm.R
+++ b/R/hmm.R
@@ -268,7 +268,7 @@ msm.misccovinits2hcovinits <- function(misccovinits, hcovariates, emodel, ecmode
 
 msm.econstr2hconstr <- function(econstr, hmodel)
   {
-      constr <- seq(length=hmodel$totpars)
+      constr <- seq(length.out=hmodel$totpars)
       for (i in unique(econstr)) {
           constr[hmodel$plabs == "p"][econstr == i] <-
             min(constr[hmodel$plabs == "p"][econstr == i])
@@ -345,7 +345,7 @@ print.hmmcat <- function(x, i, j=NULL, mv=FALSE)
     inds <- if (mv) x$parstate==i & x$parout==j else x$parstate==i
     pars <- x$pars[inds]
     res <- matrix(pars[3:(2+pars[1])], ncol=1)
-    rownames(res) <- paste("P(",seq(length=pars[1]),")",sep="")
+    rownames(res) <- paste("P(",seq(length.out=pars[1]),")",sep="")
     if (x$fitted && x$foundse) {
         ci <- matrix(x$ci[inds,], ncol=2)
         res <- cbind(res,  ci[3:(2+pars[1]),])
@@ -377,7 +377,7 @@ msm.form.hconstraint <- function(constraint, hmodel)
 
 msm.form.hcovconstraint <- function(constraint, hmodel)
   {
-      constr <- seq(length=hmodel$ncoveffs)
+      constr <- seq(length.out=hmodel$ncoveffs)
       for (con in names(constraint)) {
           if ( ! (con %in% c(hmodel$plabs, hmodel$covlabels)))
             stop("parameter \"", con, "\" in hconstraint unknown")

--- a/R/msm.R
+++ b/R/msm.R
@@ -473,7 +473,7 @@ msm.form.emodel <- function(ematrix, econstraint=NULL, initprobs=NULL, est.initp
         constr <- match(econstraint, unique(econstraint))
     }
     else
-        constr <- seq(length=npars)
+        constr <- seq(length.out=npars)
     ndpars <- if(npars>0) max(constr) else 0
 
     nomisc <- isTRUE(all.equal(as.vector(diag(ematrix)),rep(1,nrow(ematrix)))) # degenerate ematrix with no misclassification: all 1 on diagonal
@@ -1086,8 +1086,8 @@ msm.form.params <- function(qmodel, qcmodel, emodel, hmodel, fixedpars)
                 if(is.null(qcmodel$constr)) NULL else (ni + abs(qcmodel$constr))*sign(qcmodel$constr),
                 ni + nc + hmodel$constr,
                 ni + nc + nh + hmodel$covconstr,
-                ni + nc + nh + nhc + seq(length=nip),
-                ni + nc + nh + nhc + nip + seq(length=nipc))
+                ni + nc + nh + nhc + seq(length.out=nip),
+                ni + nc + nh + nhc + nip + seq(length.out=nipc))
     constr <- match(abs(constr), unique(abs(constr)))*sign(constr)
     ## parameters which are always fixed and not included in user-supplied fixedpars
     auxpars <- which(plabs %in% .msm.AUXPARS)
@@ -1098,7 +1098,7 @@ msm.form.params <- function(qmodel, qcmodel, emodel, hmodel, fixedpars)
     nshortpars <- nrealpars - sum(qcmodel$cri[!duplicated(qcmodel$constr)]==0)
     if (is.logical(fixedpars))
         fixedpars <- if (fixedpars == TRUE) seq(nshortpars) else numeric()
-    if (any(! (fixedpars %in% seq(length=nshortpars))))
+    if (any(! (fixedpars %in% seq(length.out=nshortpars))))
         stop ( "Elements of fixedpars should be in 1, ..., ", nshortpars)
     if (!is.null(qcmodel$cri)) {
         ## Convert user-supplied fixedpars indexing transition-specific covariates
@@ -1106,7 +1106,7 @@ msm.form.params <- function(qmodel, qcmodel, emodel, hmodel, fixedpars)
         inds <- rep(1, nrealpars)
         inds[qmodel$ndpars + qcmodel$constr[!duplicated(qcmodel$constr)]] <-
             qcmodel$cri[!duplicated(qcmodel$constr)]
-        inds[inds==1] <- seq(length=nshortpars)
+        inds[inds==1] <- seq(length.out=nshortpars)
         fixedpars <- match(fixedpars, inds)
         ## fix covariate effects not included in model to zero
         fixedpars <- sort(c(fixedpars, which(inds==0)))
@@ -1803,7 +1803,7 @@ msm.check.covlist <- function(covlist, qemodel) {
     tm <- if(inherits(qemodel,"msmqmodel")) "transition" else "misclassification"
     qe <- if(inherits(qemodel,"msmqmodel")) "qmatrix" else "ematrix"
     imat <- qemodel$imatrix
-    for (i in seq(length=ncol(trans))){
+    for (i in seq(length.out=ncol(trans))){
         if (imat[trans[1,i],trans[2,i]] != 1)
             stop("covariates on ", names(covlist)[i], " ", tm, " requested, but this is not permitted by the ", qe, ".")
     }

--- a/R/outputs.R
+++ b/R/outputs.R
@@ -35,7 +35,7 @@ qmatrix.msm <- function(x, covariates="mean", sojourn=FALSE, ci=c("delta","norma
             form <- as.formula(paste("~", expsum(seq(nc + 1), coefs)))
             lform <- as.formula(paste("~", lsum(seq(nc + 1), coefs)))
             ## indices into estimates vector of all intens/miscs, intens covs / misc covs
-            inds <- seq(length=x$qmodel$npars + x$qcmodel$npars)
+            inds <- seq(length.out=x$qmodel$npars + x$qcmodel$npars)
             for (i in 1 : ni){
                 ## indices into estimates vector of all intens/miscs, intens covs / misc covs for that particular fromstate-tostate.
                 parinds <- inds[seq(i, (nc * ni + i), ni)]
@@ -268,11 +268,11 @@ p.se.msm <- function(x, covariates)
         nir <- sum(hmodel$parstate[hmodel$plabs=="p"] == i) # number of independent misc probs for current state
         if (nir > 0){  # might be perfect misclassification
             p.inds <- which(hmodel$plabs=="p" & hmodel$parstate==i) # indices into HMM parameter vector of logit baseline p for that state
-            cov.inds <- sum(hmodel$npars) + (cur.i-1)*nc + seq(length=(nc*nir)) # indices into HMM parameter vector of corresp cov effects
+            cov.inds <- sum(hmodel$npars) + (cur.i-1)*nc + seq(length.out=(nc*nir)) # indices into HMM parameter vector of corresp cov effects
             parinds <- numeric(); formstr <- character(nir)
             for (j in 1:nir) {
                 formstr[j] <- expsum(1:((nc+1)*nir), coefs) # string of form exp(1*x1+beta1*x2*beta2*x3), exp(x4+beta*x5+...)
-                parinds <- c(parinds, p.inds[j], cov.inds[(j-1)*nc + seq(length=nc)]) # indices into HMM par vector corresp to x1,x2,x3,...
+                parinds <- c(parinds, p.inds[j], cov.inds[(j-1)*nc + seq(length.out=nc)]) # indices into HMM par vector corresp to x1,x2,x3,...
             }
             sumstr <- paste(formstr, collapse = " + ") # "parinds" are
             formstr <- paste("1 / (1 + ", sumstr, ")")
@@ -312,9 +312,9 @@ qratio.se.msm <- function(x, ind1, ind2, covariates, cl=0.95)
     covlist <- msm.parse.covariates(x, covariates, x$qcmodel)    
     nc <- length(covlist)
     indmat <- t(x$qmodel$imatrix)
-    indmat[indmat == 1] <- seq(length = x$qmodel$npars)
+    indmat[indmat == 1] <- seq(length.out = x$qmodel$npars)
     indmat <- t(indmat) # matrix of indices of estimate vector
-    inds <- seq(length = x$qmodel$npars+x$qcmodel$npars) # identifiers for q and beta parameters
+    inds <- seq(length.out = x$qmodel$npars+x$qcmodel$npars) # identifiers for q and beta parameters
     coefs <- as.numeric(c(1, unlist(covlist)))
     parinds <- numeric()
     indmatrow.n <- indmat[ind1[1],-ind1[1]]
@@ -390,9 +390,9 @@ qmatrix.diagse.msm <- function(x, covlist, sojourn, ni, ivector, nc)
     nst <- x$qmodel$nstates
     diagse <- diaglse <- sojse <- sojlse <- numeric(nst)
     indmat <- matrix(ivector, nst, nst)
-    indmat[indmat==1] <- seq(length = ni)
+    indmat[indmat==1] <- seq(length.out = ni)
     indmat <- t(indmat) # matrix of indices of estimate vector
-    inds <- seq(length = ni + ni*nc)
+    inds <- seq(length.out = ni + ni*nc)
     cur.i <- 1
     coefs <- as.numeric(c(1, unlist(covlist)))
     for (i in 1:nst){
@@ -445,7 +445,7 @@ msm.fill.pci.covs <- function(x, covariates="mean"){
     covlistlist <- vector(ncut+1, mode="list")
     names(covlistlist) <- levels(x$data$mf$timeperiod)
     covlistlist[[1]] <- covlist
-    for (i in seq(length=ncut)){
+    for (i in seq(length.out=ncut)){
         covlistlist[[i+1]] <- covlist
         covlistlist[[i+1]][[ti[i]]] <- 1
     }
@@ -532,7 +532,7 @@ msm.form.qoutput <- function(x, covariates="mean", cl=0.95, digits=4, ...){
     rownames(fres) <- rownames(y)
     fres[,1] <- format.ci(y[,1],y[,2],y[,3],y[,4],digits=digits,...)
     im <- t(x$qmodel$imatrix); diag(im) <- -colSums(im); nd <- which(im[im!=0]==1)
-    for (i in seq(length=x$qcmodel$ncovs)){
+    for (i in seq(length.out=x$qcmodel$ncovs)){
         nm <- x$qcmodel$covlabels[[i]]
         hrs <- mattotrans(x, x$Qmatrices[[nm]], x$QmatricesL[[nm]], x$QmatricesU[[nm]], x$QmatricesFixed[[nm]], keep.diag=FALSE)
         hrs[,1:3] <- exp(hrs[,1:3])
@@ -556,7 +556,7 @@ msm.form.eoutput <- function(x, covariates="mean", cl=0.95, digits=4, ...){
     rownames(frese) <- rownames(y)
     frese[,1] <- format.ci(y[,1],y[,2],y[,3],y[,4],digits=digits,...)
     im <- t(x$emodel$imatrix); diag(im) <- -colSums(im); nd <- which(im[im!=0]==1)
-    for (i in seq(length=x$ecmodel$ncovs)){
+    for (i in seq(length.out=x$ecmodel$ncovs)){
         nm <- x$ecmodel$covlabels[[i]]
         ors <- mattotrans(x, x$Ematrices[[nm]], x$EmatricesL[[nm]], x$EmatricesU[[nm]], x$EmatricesFixed[[nm]], keep.diag=FALSE, intmisc="misc")
         ors[,1:3] <- exp(ors[,1:3])
@@ -775,15 +775,15 @@ surface.msm <- function(x, params=c(1,2), np=10, type=c("contour","filled.contou
     if (is.null(xrange)) {
         pmin <- point[i1] - 2*se[i1]
         pmax <- point[i1] + 2*se[i1]
-        p1 <- seq(pmin, pmax, length=np)
+        p1 <- seq(pmin, pmax, length.out=np)
     }
-    else p1 <- seq(xrange[1], xrange[2], length=np)
+    else p1 <- seq(xrange[1], xrange[2], length.out=np)
     if (is.null(yrange)){
         pmin <- point[i2] - 2*se[i2]
         pmax <- point[i2] + 2*se[i2]
-        p2 <- seq(pmin, pmax, length=np)
+        p2 <- seq(pmin, pmax, length.out=np)
     }
-    else p2 <- seq(yrange[1], yrange[2], length=np)
+    else p2 <- seq(yrange[1], yrange[2], length.out=np)
 
     z <- matrix(nrow=np, ncol=np)
     for (i in 1:np) {
@@ -1500,7 +1500,7 @@ observed.msm <- function(x, times=NULL, interp=c("start","midpoint"), censtime=I
             j <- j+1
         }
     }
-    obstab <- t(apply(states.expand, 2, function(y) table(factor(y, levels=seq(length=x$qmodel$nstates)))))
+    obstab <- t(apply(states.expand, 2, function(y) table(factor(y, levels=seq(length.out=x$qmodel$nstates)))))
     obsperc <- 100*obstab / rep(rowSums(obstab), ncol(obstab))
     dimnames(obstab) <- dimnames(obsperc) <- list(times, paste("State", 1:x$qmodel$nstates))
     obstab <- cbind(obstab, Total=rowSums(obstab))
@@ -1512,7 +1512,7 @@ observed.msm <- function(x, times=NULL, interp=c("start","midpoint"), censtime=I
     risk <- matrix(nrow=length(times), ncol=length(unique(covcat)), dimnames = list(times, unique(covhist$hist)))
     for (i in seq_along(unique(covcat))) {
         obst <- t(apply(states.expand[covcat==unique(covcat)[i],,drop=FALSE], 2,
-                        function(y) table(factor(y, levels=seq(length=x$qmodel$nstates)))))
+                        function(y) table(factor(y, levels=seq(length.out=x$qmodel$nstates)))))
         risk[,i] <- rowSums(obst)
     }
 
@@ -1655,11 +1655,11 @@ plot.prevalence.msm <- function(x, mintime=NULL, maxtime=NULL, timezero=NULL, in
     time <- model.extract(x$data$mf, "time")
     if (is.null(mintime)) mintime <- min(time)
     if (is.null(maxtime)) maxtime <- max(time)
-    t <- seq(mintime, maxtime, length=100)
+    t <- seq(mintime, maxtime, length.out=100)
     obs <- observed.msm(x, t, interp, censtime, subset)
     expec <- expected.msm(x, t, timezero=timezero, initstates=initstates, covariates=covariates, misccovariates=misccovariates,
                           piecewise.times=piecewise.times, piecewise.covariates=piecewise.covariates, risk=obs$risk, subset=subset, ci="none")[[2]]
-    states <- seq(length=x$qmodel$nstates)
+    states <- seq(length.out=x$qmodel$nstates)
     S <- length(states)
     ncols <- ceiling(sqrt(S))
     nrows <- if (floor(sqrt(S))^2 < S && S <= floor(sqrt(S))*ceiling(sqrt(S))) floor(sqrt(S)) else ceiling(sqrt(S))

--- a/R/utils.R
+++ b/R/utils.R
@@ -132,7 +132,7 @@ rtnorm <- function (n, mean = 0, sd = 1, lower = -Inf, upper = Inf) {
     upper <- rep(upper, length=n)
     lower <- (lower - mean) / sd ## Algorithm works on mean 0, sd 1 scale
     upper <- (upper - mean) / sd
-    ind <- seq(length=n)
+    ind <- seq(length.out=n)
     ret <- numeric(n)
     nas <- is.na(mean) | is.na(sd) | is.na(lower) | is.na(upper)
     if (any(nas)) warning("NAs produced")

--- a/tests/slow/test_fits_hmmmulti.r
+++ b/tests/slow/test_fits_hmmmulti.r
@@ -3,7 +3,7 @@ context("HMMs with multivariate responses: model fitting")
 ## Simulate data from a Markov model 
 nsubj <- 30; nobspt <- 5
 sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt),
-                     time = seq(0, 20, length=nobspt))
+                     time = seq(0, 20, length.out=nobspt))
 set.seed(1)
 two.q <- rbind(c(-0.1, 0.1), c(0, 0))
 dat <- simmulti.msm(sim.df[,1:2], qmatrix=two.q, drop.absorb=FALSE)

--- a/tests/slow/test_fits_misc.r
+++ b/tests/slow/test_fits_misc.r
@@ -78,7 +78,7 @@ test_that("misclassification covariate constraints in misclassification models",
 
 test_that("estimating initprobs",{
     nsubj <- 50; nobspt <- 6
-    sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length=nobspt),
+    sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length.out=nobspt),
                          x = rnorm(nsubj*nobspt), y = rnorm(nsubj*nobspt)* 5 + 2 )
     (three.q <- rbind(c(0, exp(-3), exp(-6)), c(0, 0, exp(-3)), c(0, 0, 0)))
     ematrix3 <- rbind(c(0, 0.1, 0), c(0.1, 0, 0), c(0,0,0))
@@ -93,7 +93,7 @@ test_that("estimating covariate effects on initprobs",{
     nsubj <- 500; nobspt <- 6
     set.seed(22061976)
     sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt),
-                         time = seq(0, 20, length=nobspt),
+                         time = seq(0, 20, length.out=nobspt),
                          x = rnorm(nsubj*nobspt))
     (three.q <- (rbind(c(0, exp(-3), exp(-6)),
                        c(0, 0, exp(-3)),

--- a/tests/testthat/test_analyticp.r
+++ b/tests/testthat/test_analyticp.r
@@ -3,7 +3,7 @@ context("analytic transition probability matrices")
 fixq <- function(Q){ diag(Q) <- 0;  diag(Q) <- - rowSums(Q); Q } # avoid namespace faff
 
 nsubj <- 50; nobspt <- 6
-sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length=nobspt), x = rnorm(nsubj*nobspt), y = rnorm(nsubj*nobspt)* 5 + 2 )
+sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length.out=nobspt), x = rnorm(nsubj*nobspt), y = rnorm(nsubj*nobspt)* 5 + 2 )
 set.seed(22061976)
 
 test_that("2 state analytic P matrices",{
@@ -38,7 +38,7 @@ test_that("3 state analytic P matrices",{
 
                                         # 4,5 (== 1,4)
     nsubj <- 500; nobspt <- 6
-    sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length=nobspt),
+    sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length.out=nobspt),
                          x = rnorm(nsubj*nobspt), y = rnorm(nsubj*nobspt)* 5 + 2 )
     (three.q <- fixq(rbind(c(0, 0, 0), c(0, 0, exp(-2)), c(exp(-3), 0, 0))))
     sim2.df <- simmulti.msm(sim.df[,1:2], qmatrix=three.q, start=rep(2,500))
@@ -49,7 +49,7 @@ test_that("3 state analytic P matrices",{
     ## 1,6
     (three.q <- fixq(rbind(c(0, exp(-3), 0), c(0, 0, 0), c(0, exp(-3), 0))))
     nsubj <- 50; nobspt <- 6
-    sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length=nobspt), x = rnorm(nsubj*nobspt), y = rnorm(nsubj*nobspt)* 5 + 2 )
+    sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length.out=nobspt), x = rnorm(nsubj*nobspt), y = rnorm(nsubj*nobspt)* 5 + 2 )
     set.seed(22061976)
     sim2.df <- simmulti.msm(sim.df[,1:2], qmatrix=three.q, start=c(rep(3,25),rep(1,25)))
     (sim.mod1 <- msm(state ~ time, subject=subject, data=sim2.df, qmatrix = rbind(c(0, exp(-1), 0), c(0, 0, 0), c(0, exp(-1), 0)), analyticp=TRUE))

--- a/tests/testthat/test_deriv.r
+++ b/tests/testthat/test_deriv.r
@@ -143,13 +143,13 @@ test_that("Information matrix",{
 
 set.seed(22061976)
 nsubj <- 100; nobspt <- 6
-sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length=nobspt),
+sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length.out=nobspt),
                      x = rnorm(nsubj*nobspt), y = rnorm(nsubj*nobspt)* 5 + 20)
 three.q <- rbind(c(0, exp(-6), exp(-9)), c(0, 0, exp(-6)), c(0, 0, 0))
 
 set.seed(22061976)
 nsubj <- 100; nobspt <- 6
-sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length=nobspt),
+sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt), time = seq(0, 20, length.out=nobspt),
                      x = rnorm(nsubj*nobspt), y = rnorm(nsubj*nobspt)* 5 + 20)
 
 test_that("poisson",{

--- a/tests/testthat/test_models_hmmmulti.r
+++ b/tests/testthat/test_models_hmmmulti.r
@@ -3,7 +3,7 @@ context("HMMs with multivariate responses")
 ## Simulate data from a Markov model 
 nsubj <- 30; nobspt <- 5
 sim.df <- data.frame(subject = rep(1:nsubj, each=nobspt),
-                     time = seq(0, 20, length=nobspt))
+                     time = seq(0, 20, length.out=nobspt))
 suppressWarnings(RNGversion("3.5.0"))
 set.seed(1)
 two.q <- rbind(c(-0.1, 0.1), c(0, 0))


### PR DESCRIPTION
I got warnings while playing around with this (great!) package

```r
-2 * log-likelihood:  3968.798 
[Note, to obtain old print format, use "printold.msm"]
Warning messages:
1: In seq.default(length = x$qmodel$npars + x$qcmodel$npars) :
  partial argument match of 'length' to 'length.out'
2: In seq.default(length = ni) :
  partial argument match of 'length' to 'length.out'
3: In seq.default(length = ni + ni * nc) :
  partial argument match of 'length' to 'length.out'
4: In seq.default(length = x$qcmodel$ncovs) :
  partial argument match of 'length' to 'length.out'
```

So I went in and replaced all `length` with `length.out`.