### PR TITLE
Faster rpexp that also allows for t != 0 and left truncation

### DIFF
--- a/man/pexp.Rd
+++ b/man/pexp.Rd
@@ -14,7 +14,7 @@
      dpexp(x, rate=1, t=0, log = FALSE)
      ppexp(q, rate=1, t=0, lower.tail = TRUE, log.p = FALSE)
      qpexp(p, rate=1, t=0, lower.tail = TRUE, log.p = FALSE)
-     rpexp(n, rate=1, t=0)
+     rpexp(n, rate=1, t=0, start=min(t))
 }
 \arguments{
 
@@ -24,12 +24,13 @@
     taken to be the number required.}
   \item{rate}{vector of rates.}
   \item{t}{vector of the same length as \code{rate}, giving the times at
-    which the rate changes. The first element of \code{t} should be 0,
-    and \code{t} should be in increasing order.}
+    which the rate changes. The values of \code{t} should be in increasing order.}
   \item{log, log.p}{logical; if TRUE, probabilities p are given as
     log(p), or log density is returned.}
   \item{lower.tail}{logical; if TRUE (default), probabilities are P[X <= x],
     otherwise, P[X > x].}
+  \item{start}{numeric scalar; delayed entry time. The random deviates
+  will be left truncated from this start time.}
 }
 \value{
      \code{dpexp} gives the density, \code{ppexp} gives the distribution

--- a/tests/testthat/test_utils.r
+++ b/tests/testthat/test_utils.r
@@ -108,6 +108,14 @@ test_that("Exponential distribution with piecewise constant hazard",{
     set.seed(220676)
     r <- rexp(10)
     expect_equal(rt, r, tol=1e-06)
+
+    set.seed(12345)
+    expect_equal(rpexp(1, rate=1:3, t = 0:2), 0.4418078, tol=1e-6)
+    expect_equal(rpexp(1, rate=1:3, t = 1:3), 1.527473, tol=1e-6)
+    expect_equal(rpexp(1, rate=0:2, t = 0:2), 1.808467, tol=1e-6)
+    expect_equal(rpexp(1, rate=c(0.01,0), t = 0:1), Inf)
+    expect_equal(rpexp(1, rate=1:3, t = 0:2, start=1.7), 1.927705, tol=1e-6)
+    expect_equal(rpexp(1, rate=0:2, t = 0:2, start=4), 4.011969, tol=1e-6)
 })
 
 test_that("deltamethod",{


### PR DESCRIPTION
Chris,

I have written a new version of the `rpexp` function. This uses `findInterval` to find the cumulative hazard that equals a unit exponential draw. I have also allowed for the first time to not equal 0 and allowed for left truncation.

I have compared the execution times and the new implementation is consistent faster (in the benchmark, `rpexp` is the old version and `rpexp2` is the new version):
```
> microbenchmark(rpexp(1, rate=rep(0.2,11), t = 0:10),
+                rpexp2(1, rate=rep(0.2,11), t = 0:10))
Unit: microseconds
                                     expr    min      lq     mean  median
  rpexp(1, rate = rep(0.2, 11), t = 0:10) 36.541 49.1730 73.75605 60.1995
 rpexp2(1, rate = rep(0.2, 11), t = 0:10) 20.844 22.2755 24.16660 24.3455
      uq     max neval cld
 91.3535 140.594   100   b
 25.2755  51.420   100  a 
> microbenchmark(rpexp(1e3, rate=rep(0.2,11), t = 0:10),
+                rpexp2(1e3, rate=rep(0.2,11), t = 0:10))
Unit: microseconds
                                        expr     min       lq     mean   median
  rpexp(1000, rate = rep(0.2, 11), t = 0:10) 479.533 512.6445 559.5166 576.7735
 rpexp2(1000, rate = rep(0.2, 11), t = 0:10)  83.338  93.8460 102.8353 104.8005
       uq     max neval cld
 600.2675 650.896   100   b
 110.1755 166.025   100  a 
> microbenchmark(rpexp(1, rate=rep(0.02,101), t = 0:100),
+                rpexp2(1, rate=rep(0.02,101), t = 0:100))
Unit: microseconds
                                        expr    min      lq      mean   median
  rpexp(1, rate = rep(0.02, 101), t = 0:100) 41.631 162.565 460.11658 381.2595
 rpexp2(1, rate = rep(0.02, 101), t = 0:100) 22.551  25.073  28.48999  27.4140
       uq      max neval cld
 713.5655 1036.355   100   b
  30.1550   68.422   100  a 
> microbenchmark(rpexp(1e3, rate=rep(0.02,101), t = 0:100),
+                rpexp2(1e3, rate=rep(0.02,101), t = 0:100))
Unit: microseconds
                                           expr      min        lq      mean
  rpexp(1000, rate = rep(0.02, 101), t = 0:100) 3719.806 3810.6005 4114.5973
 rpexp2(1000, rate = rep(0.02, 101), t = 0:100)  103.110  107.2595  115.1173
   median       uq      max neval cld
 3886.346 4086.510 7970.679   100   b
  112.640  117.186  179.435   100  a 
```
I hope that this is useful. 

Sincerely, Mark.